### PR TITLE
Fix for Blender 4.4

### DIFF
--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -72,11 +72,11 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         description="Specify object material colors in Color Group instead of Base Material",
         default=False)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
         Initialize some fields with defaults before starting.
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.next_resource_id = 1  # Which resource ID to generate for the next object.
         self.num_written = 0  # How many objects we've written to the file.
         self.material_resource_id = -1  # We write one material. This is the resource ID of that material.

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -64,11 +64,11 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         description="Import object material colors from Color Group. Overrides any Base Materials with same id found.",
         default=True)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
         Initializes the importer with empty fields.
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.resource_objects = {}  # Dictionary mapping resource IDs to ResourceObjects.
 
         # Dictionary mapping resource IDs to dictionaries mapping indexes to ResourceMaterial objects.


### PR DESCRIPTION
Applies Blender's new requirement for subclasses to contain arguments of their parent classes at init.